### PR TITLE
fix(tests): bump up kepler version in internals e2e

### DIFF
--- a/tests/e2e/kepler_internal_test.go
+++ b/tests/e2e/kepler_internal_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	keplerImage = `quay.io/sustainable_computing_io/kepler:release-0.7.11`
+	keplerImage = `quay.io/sustainable_computing_io/kepler:release-0.7.12`
 )
 
 func TestKeplerInternal_Reconciliation(t *testing.T) {


### PR DESCRIPTION
This commit bumps up Kepler version used in internals e2e tests which was left in previous bump up commit #435