### PR TITLE
fix(gomod): changed go version to 1.22.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.23 AS builder
+FROM golang:1.22 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/sustainable.computing.io/kepler-operator
 
-go 1.23
+go 1.22
 
-toolchain go1.23.3
+toolchain go1.22.9
 
 require (
 	github.com/cespare/xxhash/v2 v2.2.0


### PR DESCRIPTION
Since go1..22 is not available in golang builder base image, use go1.22