### PR TITLE
Revert "chore(go): use go 1.22"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/sustainable.computing.io/kepler-operator
 
-go 1.22.0
+go 1.23
 
-toolchain go1.24.1
+toolchain go1.23.3
 
 require (
 	dario.cat/mergo v1.0.0


### PR DESCRIPTION
This reverts commit fd7331b67e575b50b5ddc842429e26aab9f4a65a.